### PR TITLE
add mqtt broker and mqtt hub

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -24,6 +24,19 @@ docker buildx build -t dougflynn/iot-api-plants:latest --platform linux/arm64 -f
 echo "DONE. Swapping back to root dir"
 cd ..
 
+echo "Building MQTT handler"
+cd iot-mqtt-hub
+echo "Creating arm64 docker image and pushing"
+docker buildx build -t dougflynn/iot-mqtt-hub:latest --platform linux/arm64 -f Dockerfile.prod --push .
+
+echo "Skipping mosquitto image, already supports arm64"
+# cd iot-mqtt-broker
+# echo "Creating arm64 docker image and pushing"
+# docker buildx build -t dougflynn/iot-mqtt-hub:latest --platform linux/arm64 -f Dockerfile.prod --push .
+
+echo "DONE. Swapping back to root dir"
+cd ..
+
 echo "NOTHING LEFT TO DO :)"
 
 echo "Run the following to push to prod/swarm:"

--- a/docker-compose-prod.yml
+++ b/docker-compose-prod.yml
@@ -33,6 +33,37 @@ services:
         aliases:
           - iot-api-plants
 
+  iot-mqtt-hub:
+    image: dougflynn/iot-mqtt-hub:latest
+    build: iot-mqtt-hub
+    # depends_on:
+    #   - database
+    deploy:
+      replicas: 1
+    ports:
+      - 8001:8001
+    volumes:
+      - "./iot-mqtt-hub:/app"
+    networks:
+      iot-backend:
+        aliases:
+          - iot-mqtt-hub
+
+  iot-mqtt-broker:
+    image: eclipse-mosquitto
+    deploy:
+      replicas: 1
+    ports:
+      - 1883:1883
+      - 9001:9001
+    volumes:
+      - "./iot-mqtt-hub:/app"
+    networks:
+      iot-backend:
+        aliases:
+          - iot-mqtt-broker
+
+
 
   # Not doing anything yet, but still needed
   database:
@@ -41,8 +72,6 @@ services:
       - .db.env
     deploy:
       replicas: 1
-
-# Persistent https certs
 
 networks:
   iot-backend:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,6 +29,33 @@ services:
         aliases:
           - iot-api-plants
 
+  iot-mqtt-hub:
+    image: iot-mqtt-hub
+    build: iot-mqtt-hub
+    # depends_on:
+    #   - database
+    ports:
+      - 8002:8002
+    volumes:
+      - "./iot-mqtt-hub:/app"
+    networks:
+      iot-backend:
+        aliases:
+          - iot-mqtt-hub
+
+  iot-mqtt-broker:
+    image: eclipse-mosquitto
+    ports:
+      - 1883:1883
+      - 9001:9001
+    volumes:
+      - "./iot-mqtt-hub:/app"
+    networks:
+      iot-backend:
+        aliases:
+          - iot-mqtt-broker
+
+
 
   # Not doing anything yet, but still needed
   database:

--- a/iot-auth-server/Dockerfile.arm
+++ b/iot-auth-server/Dockerfile.arm
@@ -1,7 +1,0 @@
-FROM debian:stretch-slim
-
-WORKDIR /app
-
-COPY ./target/aarch64-unknown-linux-gnu/release/iot-auth ./
-
-CMD ["./iot-auth"]

--- a/iot-mqtt-hub/Dockerfile
+++ b/iot-mqtt-hub/Dockerfile
@@ -1,0 +1,5 @@
+FROM python:slim
+WORKDIR /app
+COPY . /app
+RUN pip install -r requirements.txt
+CMD ["python", "main.py"]

--- a/iot-mqtt-hub/main.py
+++ b/iot-mqtt-hub/main.py
@@ -1,0 +1,1 @@
+print("mqtt broker")

--- a/iot-mqtt-hub/requirements.txt
+++ b/iot-mqtt-hub/requirements.txt
@@ -1,0 +1,1 @@
+requests

--- a/mosquitto.conf
+++ b/mosquitto.conf
@@ -1,0 +1,3 @@
+persistence true
+persistence_location /mosquitto/data/
+log_dest file /mosquitto/log/mosquitto.log


### PR DESCRIPTION
Adds basic mqtt broker and start to mqtt hub (the hub will subscribe to all requests and routes them to other services)

I've done this before, but apparently none of that is in a git repo anywhere... That's okay because this is docker based now vs bare metal